### PR TITLE
Add masonry to layout for card rearranging

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -10,6 +10,18 @@
  * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
  * file per style scope.
  *
- *= require_tree .
- *= require_self
  */
+ /**= require_tree .
+ *= require_self*/
+
+.grid-item {
+  width: 315px;
+}
+
+.grid {
+  margin: 0 auto;
+}
+
+.card-title {
+  opacity: 0.8;
+}

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,4 +1,7 @@
 <h2> <%= @category.name %> </h2>
-<% @category.items.each do |item| %>
-  <%= render partial: "shared/item_card", locals: { item: item }%>
-<% end %>
+
+<div class="grid">
+  <% @category.items.each do |item| %>
+    <%= render partial: "shared/item_card", locals: { item: item }%>
+  <% end %>
+</div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,7 +1,7 @@
-<h1>Art Index</h1>
+<h2>Art Index</h2>
 
-<ul>
+<div class="grid">
   <% @items.each do |item|  %>
     <%= render partial: "shared/item_card", locals: { item: item }%>
   <% end %>
-</ul>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,13 +8,28 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.5/css/materialize.min.css">
    <!-- Compiled and minified JavaScript -->
    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.5/js/materialize.min.js"></script>
+   <!-- Load masonry files -->
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/masonry/3.3.2/masonry.pkgd.min.js"></script>
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.imagesloaded/4.0.0/imagesloaded.pkgd.js"></script>
   </head>
   <body>
   <%= render partial: "layouts/navbar" %>
 
-  <div class="container">
+  <div class="container center-align">
     <%= yield %>
   </div>
+
+  <script type="text/javascript">
+    $grid = $('.grid');
+
+    $grid.imagesLoaded( function(){
+      $grid.masonry({
+        itemSelector: '.grid-item',
+        columnWidth: 370,
+        isFitWidth: true
+      });
+    });
+  </script>
 
   </body>
 </html>

--- a/app/views/shared/_item_card.html.erb
+++ b/app/views/shared/_item_card.html.erb
@@ -1,10 +1,8 @@
-<div class="row">
-  <div class="col s12 m7">
-    <div class="card">
-      <div class="card-image">
-        <%= image_tag item.image_path %>
-        <span class="card-title blue-grey"><%= item.title %></span>
-      </div>
+<div class="grid-item">
+  <div class="card">
+    <div class="card-image">
+      <%= image_tag item.image_path %>
+      <span class="card-title blue-grey"><%= item.title %></span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Use masonry and jQuery to get a dynamic layout for the cards on the
items index and category show pages.
There are 3 columns in the large layout, 2 in the medium, and 1 in
the small. Columns are always centered and are not arranged until
images have been loaded. Card titles are also 80% opaque.