### PR TITLE
Move cart item to partial view

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -6,6 +6,10 @@ img {
   max-width: 100%;
 }
 
+.quantity {
+  padding-left: 20px;
+}
+
 .container {
   padding-top: 20px;
 }

--- a/app/views/cart_items/_item.html.erb
+++ b/app/views/cart_items/_item.html.erb
@@ -1,0 +1,14 @@
+<div class="row">
+  <div class="col m4 s12">
+    <%= image_tag item.image_path, class: 'img-small' %>
+  </div>
+  <div class="col m8 s12 left-align">
+    <h5><%= item.title %> by <%= item.artist.first_name %> <%= item.artist.last_name %></h5>
+    <p><%= item.description %></p>
+    <p>
+      <span>Price: $<%= item.price %></span>
+      <span class="quantity">Quantity: <%=  quantity %></span>
+    </p>
+      <%= link_to "Remove", cart_item_path(item), method: :delete %>
+  </div>
+</div>

--- a/app/views/cart_items/index.html.erb
+++ b/app/views/cart_items/index.html.erb
@@ -1,16 +1,5 @@
 <% @items_with_quantities.each do |item, quantity| %>
-  <div class="row valign-wrapper">
-    <div class="col m4 s12 valign">
-      <%= image_tag item.image_path, class: 'img-small' %>
-    </div>
-    <div class="col m8 s12 left-align valign">
-      <h5><%= item.title %> by <%= item.artist.first_name %> <%= item.artist.last_name %></h5>
-      <p><%= item.description %></p>
-      <p>Price: $<%= item.price %></p>
-      <p>Quantity: <%=  quantity %></p>
-        <%= link_to "Remove", cart_item_path(item), method: :delete %>
-    </div>
-  </div>
+  <%= render partial: 'item', locals: { item: item, quantity: quantity } %>
 <% end %>
 
 <h3>Total: $<%= @total %></h3>


### PR DESCRIPTION
The cart index now uses a partial to render each item in the cart.
Additionally, within this view, the quantity and price are now
on the same line. There is an additional class added to quantity so
that it is 20pixels away from the price.

Also removes the valign because this allows the view to look better
when the screen is mobile-size by moving the text below the images.
We may want to consider dynamically adding valign classes with jquery
for larger screen sizes.

closes #28 