### PR TITLE
Turn item card image into a link to item show page

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -6,6 +6,10 @@ img {
   max-width: 100%;
 }
 
+.quantity {
+  padding-left: 20px;
+}
+
 .container {
   padding-top: 20px;
 }

--- a/app/views/cart_items/_item.html.erb
+++ b/app/views/cart_items/_item.html.erb
@@ -1,0 +1,14 @@
+<div class="row">
+  <div class="col m4 s12">
+    <%= image_tag item.image_path, class: 'img-small' %>
+  </div>
+  <div class="col m8 s12 left-align">
+    <h5><%= item.title %> by <%= item.artist.first_name %> <%= item.artist.last_name %></h5>
+    <p><%= item.description %></p>
+    <p>
+      <span>Price: $<%= item.price %></span>
+      <span class="quantity">Quantity: <%=  quantity %></span>
+    </p>
+      <%= link_to "Remove", cart_item_path(item), method: :delete %>
+  </div>
+</div>

--- a/app/views/cart_items/index.html.erb
+++ b/app/views/cart_items/index.html.erb
@@ -1,16 +1,5 @@
 <% @items_with_quantities.each do |item, quantity| %>
-  <div class="row valign-wrapper">
-    <div class="col m4 s12 valign">
-      <%= image_tag item.image_path, class: 'img-small' %>
-    </div>
-    <div class="col m8 s12 left-align valign">
-      <h5><%= item.title %> by <%= item.artist.first_name %> <%= item.artist.last_name %></h5>
-      <p><%= item.description %></p>
-      <p>Price: $<%= item.price %></p>
-      <p>Quantity: <%=  quantity %></p>
-        <%= link_to "Remove", cart_item_path(item), method: :delete %>
-    </div>
-  </div>
+  <%= render partial: 'item', locals: { item: item, quantity: quantity } %>
 <% end %>
 
 <h3>Total: $<%= @total %></h3>

--- a/app/views/shared/_item_card.html.erb
+++ b/app/views/shared/_item_card.html.erb
@@ -1,8 +1,8 @@
 <div class="grid-item">
   <div class="card">
-    <div class="card-image">
+    <a href="/items/<%= item.id %>" class="card-image">
       <%= image_tag item.image_path %>
-    </div>
+    </a>
     <div class="card-action">
       <span class="card-title"><%= item.title %></span>
       <%= button_to "Add to Cart", cart_items_path(item_id: item.id), class: "btn waves-effect waves-light" %>


### PR DESCRIPTION
Changes the 'div' tag to be an 'a' tag for the item image in the
item_card partial. Adds a link to go to the specific item's show page
so that when you click on the card's image you can go directly to its
page to see all of the other details.

closes #21 