### PR TITLE
Install simplecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /tmp
 
 .byebug_history
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :development, :test do
   gem "factory_girl_rails"
   gem 'database_cleaner'
   gem 'mocha'
+  gem 'simplecov', :require => false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
     concurrent-ruby (1.0.0)
     database_cleaner (1.5.1)
     debug_inspector (0.0.2)
+    docile (1.1.5)
     erubis (2.7.0)
     execjs (2.6.0)
     factory_girl (4.5.0)
@@ -137,6 +138,11 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    simplecov (0.11.1)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     spring (1.6.2)
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
@@ -181,6 +187,7 @@ DEPENDENCIES
   rails_12factor
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  simplecov
   spring
   turbolinks
   uglifier (>= 1.3.0)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,13 +24,4 @@ end
 
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
-
-  def setup
-    DatabaseCleaner.start
-  end
-
-  def teardown
-    DatabaseCleaner.clean
-    reset_session!
-  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,12 @@
 ENV["RAILS_ENV"] ||= "test"
+require "simplecov"
+SimpleCov.start "rails"
+puts "required simplecov"
 require File.expand_path("../../config/environment", __FILE__)
 require "rails/test_help"
 require "capybara/rails"
 require "database_cleaner"
 require "mocha/mini_test"
-
 DatabaseCleaner.strategy = :truncation
 
 class ActiveSupport::TestCase


### PR DESCRIPTION
Installed the simplecov gem to show overall test coverage. Added command to start gem when running test suite. 

When you run rake test it will automatically run SimpleCov and print `required simplecov` in terminal. To see test coverage results type `open coverage/index.html` in terminal. 

Also added the coverage file to our .gitignore file per README instruction. 