### PR TITLE
closes #15 viewing past orders

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,8 +1,6 @@
 class OrdersController < ApplicationController
   def index
     @orders = Order.where(user_id: current_user.id)
-    # @order_items = OrderItem.find_by(order_id: params[:order_id])
-    # byebug
   end
 
   def create
@@ -11,6 +9,7 @@ class OrdersController < ApplicationController
       OrderItem.create(order_id: order.id, item_id: item_id, quantity: quantity)
     end
 
+    @cart.contents.clear
     flash[:success] = "Order was successfully placed"
     redirect_to orders_path(order_id: order.id)
   end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -18,6 +18,10 @@ class Cart
     contents.delete(item_id.to_s)
   end
 
+  def clear
+    @contents = {}
+  end
+
   def item_quantities
     contents.map do |item_id, quantity|
       [Item.find(item_id.to_i), quantity]

--- a/test/integration/user_can_view_past_orders_test.rb
+++ b/test/integration/user_can_view_past_orders_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class UserCanViewPastOrdersTest < ActionDispatch::IntegrationTest
+  test "user sees all submitted orders" do
+    user = create(:user)
+    ApplicationController.any_instance.stubs(:current_user).returns(user)
+
+    add_two_items_to_cart
+    click_on "Checkout"
+    add_two_items_to_cart
+    click_on "Checkout"
+
+    visit orders_path
+
+    assert_equal 2, Order.all.count
+    assert page.has_content?(Order.first.id)
+    assert page.has_content?(Order.first.total)
+    assert page.has_content?(Order.last.id)
+    assert page.has_content?(Order.last.total)
+  end
+end

--- a/test/integration/user_checks_out_from_cart_test.rb
+++ b/test/integration/user_checks_out_from_cart_test.rb
@@ -2,31 +2,26 @@ require "test_helper"
 
 class UserChecksOutFromCartTest < ActionDispatch::IntegrationTest
   test "user is asked to log in then order is placed" do
-    # Background: An existing user and a cart with items
     user = create(:user)
     items = add_two_items_to_cart
-    # As a visitor
-    # When I visit "/cart"
+
     visit cart_path
-    # And I click "Checkout"
     click_button "Checkout"
-    # Then I should be required to login
+
     assert_equal login_path, current_path
+
     fill_in "Username", with: user.username
     fill_in "Password", with: user.password
     click_on "Login"
-    # When I am logged in
-    # And I visit "/cart"
+
     visit cart_path
-    # And I click "Checkout"
     click_button "Checkout"
-    # Then the order should be placed
+
     assert_equal 1, Order.count
-    # And my current page should be "/orders"
+
     assert_equal orders_path, current_path
-    # And I should see a message "Order was successfully placed"
+
     assert page.has_content?("Order was successfully placed")
-    # And I should see the order I just placed in a table
     assert page.has_content?(items.first.title)
     assert page.has_content?(items.last.title)
     assert page.has_content?(Order.last.id)


### PR DESCRIPTION
User can now visit the orders index while they are logged in and see a history of all of the orders they have placed. The history shows the order id, date, total, and the items in the order.