### PR TITLE
Create show page for individual orders

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -13,4 +13,8 @@ class OrdersController < ApplicationController
     flash[:success] = "Order was successfully placed"
     redirect_to orders_path(order_id: order.id)
   end
+
+  def show
+    @order = Order.find(params[:id])
+  end
 end

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,7 +1,7 @@
 <% @orders.each do |order| %>
   <div class="card">
     <div class="card-action">
-      <h3>Order ID: <%= order.id %></h3>
+      <h3><%=link_to "Order ID: #{order.id}", order_path(order)%></h3>
       <h5>Date Ordered: <%= order.date %></h5>
       <h5>Total: <%= order.total %></h5>
     </div>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,0 +1,15 @@
+<h3>Order ID: <%= @order.id %></h3>
+<h5>Date Ordered: <%= @order.date %></h5>
+<h5>Total: <%= @order.total %></h5>
+<h5>Status: Ordered</h5>
+
+
+<div class="items">
+  <% @order.items.each do |item| %>
+    <%= image_tag item.image_path %>
+    <%= link_to item.title, item_path(item) %>
+    Price: <%= item.price %>
+    Quantity: <%= @order.quantity_of_item(item.id) %>
+    Subtotal: <%= item.price * @order.quantity_of_item(item.id) %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   resources :categories, only: [:show], param: :slug
   resources :users, only: [:index, :new, :create]
   resources :cart_items, only: [:create, :destroy, :update]
-  resources :orders, only: [:index, :create]
+  resources :orders, only: [:index, :create, :show]
 
   get "/cart", to: "cart_items#index"
   get "/login", to: "sessions#new"

--- a/test/integration/user_sees_details_for_past_orders_test.rb
+++ b/test/integration/user_sees_details_for_past_orders_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class UserSeesDetailsForPastOrdersTest < ActionDispatch::IntegrationTest
+  test "user sees item order details and order status" do
+    user = create(:user)
+    ApplicationController.any_instance.stubs(:current_user).returns(user)
+
+    items = add_two_items_to_cart
+    click_on "Checkout"
+
+    visit orders_path
+    order = Order.first
+    assert page.has_content?(order.id)
+    assert page.has_content?(order.total)
+    assert page.has_link?("Order ID: #{order.id}", href: order_path(order))
+    click_on "Order ID: #{order.id}"
+    items.each do |item|
+      assert page.has_content?(item.title)
+      assert page.has_content?("Quantity: 1")
+      assert page.has_content?("Subtotal: #{item.price * 1}")
+      assert page.has_link?("#{item.title}", href: item_path(item))
+    end
+    assert page.has_content?("Status: Ordered")
+    assert page.has_content?("Total: #{order.total}")
+    assert page.has_content?("Date Ordered: #{order.date}")
+  end
+end


### PR DESCRIPTION
User can now click on individual orders to view more details like status. Each item in the order is linked to their show page. Doesn't fully close 16, waiting to hear back on the user story status. Currently status is hard coded in and doesn't have a place in table.