### PR TITLE
closes #42 Add styling to flash messages & checkout button

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -86,4 +86,12 @@ img {
 
 .flash_success {
   background-color: #ccff90;
+  text-align: center;
+  font-size: 1.2em;
+}
+
+.flash_error {
+  background-color: #f25050;
+  text-align: center;
+  font-size: 1.2em;
 }

--- a/app/views/cart_items/index.html.erb
+++ b/app/views/cart_items/index.html.erb
@@ -4,8 +4,10 @@
 
 <h3>Total: $<%= @total %></h3>
 
-<% if current_user %>
-  <%= button_to "Checkout", orders_path %>
-<% else %>
-  <%= button_to "Checkout", login_path, method: :get %>
-<% end %>
+<div class="row">
+  <% if current_user %>
+  <%= button_to "Checkout", orders_path, :class=> "waves-effect waves-light btn green accent-4" %>
+  <% else %>
+  <%= button_to "Checkout", login_path, method: :get, :class=> "waves-effect waves-light btn green accent-4" %>
+  <% end %>
+</div>


### PR DESCRIPTION
Adds really basic styling to the flash messages so they are either green or red, the text is centered, and the font is a little bigger. I also realized we hadn't applied the Materialize button classes to the Checkout button so I did that and made it green. I put it in a div so it wasn't sitting at the very bottom of the page. There's a little bit of space below it now. 