### PR TITLE
Add user sad path for login

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -34,6 +34,10 @@ img {
   background-size: cover;
 }
 
+.error {
+  background-color: red
+}
+
 .btn_landing_page {
   background-color: rgba(255,255,255,0.8)!important;
   height: 70px!important;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,7 @@ class UsersController < ApplicationController
       session[:user_id] = @user.id
       redirect_to dashboard_path
     else
-      redirect_to new_user_path
+      render :new
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ActiveRecord::Base
-  has_many :orders
   has_secure_password
+  validates :username, presence: true,
+                       uniqueness: true
+  has_many :orders
 end

--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -1,0 +1,8 @@
+<% if target.errors.any? %>
+  <h4> <%=  pluralize(target.errors.count, "error") %> prohibited this record from being saved: </h4>
+  <ul>
+    <% target.errors.full_messages.each do |message| %>
+      <li><strong class="error"> <%= message %> </strong> </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,5 +1,6 @@
 <h3>Create a New Account</h3>
 <%= form_for(@user) do |f| %>
+  <%= render partial: 'shared/errors', locals: {target: @user} %>
 
   <%= f.label :first_name %>
   <%= f.text_field :first_name %>

--- a/test/integration/guest_can_change_quanity_in_cart_test.rb
+++ b/test/integration/guest_can_change_quanity_in_cart_test.rb
@@ -2,7 +2,8 @@ require "test_helper"
 
 class GuestCanChangeQuanityInCartTest < ActionDispatch::IntegrationTest
   test "guest visits cart and adds more items" do
-    add_item_to_cart_and_visit_shopping_cart
+    add_items_to_cart_and_visit_shopping_cart(1)
+    @item = @items.first
     visit cart_path
 
     assert page.has_content? "Total: $#{@item.price * 1}"

--- a/test/integration/guest_creates_login_with_incorrect_creditials_test.rb
+++ b/test/integration/guest_creates_login_with_incorrect_creditials_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class GuestCreatesLoginWithIncorrectCreditialsTest < ActionDispatch::IntegrationTest
+  test "guest puts in incorrect password confirmation and gets error message" do
+    visit new_user_path
+    fill_in "First name", with: "Bruce"
+    fill_in "Last name", with: "Wayne"
+    fill_in "Username", with: "Batman"
+    fill_in "Password", with: "darkness"
+    fill_in "Password confirmation", with: "parents_dead"
+    click_on "Create Account"
+
+    assert_equal "/users", current_path
+    assert page.has_content? "Password confirmation doesn't match Password"
+  end
+
+  test "guest puts in name that is already created" do
+    create(:user)
+    visit new_user_path
+    fill_in "First name", with: "Bruce"
+    fill_in "Last name", with: "Wayne"
+    fill_in "Username", with: "user"
+    fill_in "Password", with: "darkness"
+    fill_in "Password confirmation", with: "darkness"
+    click_on "Create Account"
+
+    assert_equal "/users", current_path
+    assert page.has_content? "Username has already been taken"
+  end
+end

--- a/test/integration/user_can_create_account_test.rb
+++ b/test/integration/user_can_create_account_test.rb
@@ -2,7 +2,8 @@ require "test_helper"
 
 class UserCanCreateAccountTest < ActionDispatch::IntegrationTest
   test "user can create account and sees profile" do
-    add_item_to_cart_and_visit_shopping_cart
+    add_items_to_cart_and_visit_shopping_cart(1)
+    @item = @items.first
     assert page.has_content?(@item.title)
 
     visit "/"

--- a/test/integration/user_can_view_past_orders_test.rb
+++ b/test/integration/user_can_view_past_orders_test.rb
@@ -5,9 +5,9 @@ class UserCanViewPastOrdersTest < ActionDispatch::IntegrationTest
     user = create(:user)
     ApplicationController.any_instance.stubs(:current_user).returns(user)
 
-    add_two_items_to_cart_and_visit_shopping_cart
+    add_items_to_cart_and_visit_shopping_cart(1)
     click_on "Checkout"
-    add_two_items_to_cart_and_visit_shopping_cart
+    add_items_to_cart_and_visit_shopping_cart(1)
     click_on "Checkout"
 
     visit orders_path

--- a/test/integration/user_checks_out_from_cart_test.rb
+++ b/test/integration/user_checks_out_from_cart_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class UserChecksOutFromCartTest < ActionDispatch::IntegrationTest
   test "user is asked to log in then order is placed" do
     user = create(:user)
-    add_two_items_to_cart_and_visit_shopping_cart
+    add_items_to_cart_and_visit_shopping_cart(2)
 
     visit cart_path
     click_button "Checkout"
@@ -31,7 +31,7 @@ class UserChecksOutFromCartTest < ActionDispatch::IntegrationTest
   end
 
   test "logged in user places order" do
-    add_two_items_to_cart_and_visit_shopping_cart
+    add_items_to_cart_and_visit_shopping_cart(2)
     user = create(:user)
     ApplicationController.any_instance.stubs(:current_user).returns(user)
 

--- a/test/integration/user_removes_item_from_cart_test.rb
+++ b/test/integration/user_removes_item_from_cart_test.rb
@@ -2,12 +2,11 @@ require "test_helper"
 
 class UserRemovesItemFromCartTest < ActionDispatch::IntegrationTest
   test "item is removed from current cart" do
-    add_item_to_cart_and_visit_shopping_cart
+    add_items_to_cart_and_visit_shopping_cart(1)
+    @item = @items.first
     visit cart_path
-
     click_link "Remove"
     assert_equal cart_path, current_path
-
     success_message = "Successfully removed #{@item.title} from your cart."
     assert page.has_content?(success_message)
     assert page.has_css?(".flash_success")

--- a/test/integration/user_sees_details_for_past_orders_test.rb
+++ b/test/integration/user_sees_details_for_past_orders_test.rb
@@ -5,7 +5,7 @@ class UserSeesDetailsForPastOrdersTest < ActionDispatch::IntegrationTest
     user = create(:user)
     ApplicationController.any_instance.stubs(:current_user).returns(user)
 
-    add_two_items_to_cart_and_visit_shopping_cart
+    add_items_to_cart_and_visit_shopping_cart(2)
     click_on "Checkout"
 
     visit orders_path

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,17 +27,8 @@ end
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
 
-  def add_item_to_cart_and_visit_shopping_cart
-    @item = create(:item)
-    visit item_path(@item)
-
-    click_button "Add to Cart"
-
-    find("#shopping_cart").click
-  end
-
-  def add_two_items_to_cart_and_visit_shopping_cart
-    @items = create_list(:item, 2)
+  def add_items_to_cart_and_visit_shopping_cart(num_items = 1)
+    @items = create_list(:item, num_items)
 
     @items.each do |item|
       visit item_path(item)
@@ -47,7 +38,6 @@ class ActionDispatch::IntegrationTest
     find("#shopping_cart").click
   end
 end
-
 # Shoulda::Matchers.configure do |config|
 #   config.integrate do |with|
 #     # Choose a test framework:


### PR DESCRIPTION
In addition to adding sad path and error messages to login,
there was also a change in the test methods
add_item_to_cart_and_visit_shopping_cart which defaults at 1
but can take a integer in the argument to allow for more creations.

I don't know if this actually helped, currently it is commented out and can quickly be changed back.
Personally I like using less methods but I'm not sure if there is a huge difference from 1 vs 2.