### PR TITLE
closes #55 - Make user's name in navbar link to user dashboard

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -9,6 +9,10 @@ img {
   left: 150px;
 }
 
+.login_confirm {
+  color: #a7ffeb;
+}
+
 .img-small {
   max-width: 100%;
 }

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -3,7 +3,9 @@
     <%= link_to "RoughSketch", items_path %>
     <ul id="nav-mobile" class="right hide-on-med-and-down">
       <% if current_user %>
-        <li class="login_confirm right-align">Logged in as <%= current_user.first_name %></li>
+        <li class="right-align">
+          <%= link_to "Logged in as #{current_user.first_name}", dashboard_path(current_user) , class: "login_confirm"%>
+        </li>
       <% end %>
       <li><a href="/cart" id="shopping_cart"><i class="material-icons">shopping_cart</i></a></li>
       <li class="new badge"><%= @cart.count %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,14 +2,15 @@
 <html>
   <head>
     <title>LittleShop</title>
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+
     <%= csrf_meta_tags %>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.5/css/materialize.min.css">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
    <!-- Compiled and minified JavaScript -->
    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.5/js/materialize.min.js"></script>
+   <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
+   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
 
    <!-- Load masonry files -->
    <script src="https://cdnjs.cloudflare.com/ajax/libs/masonry/3.3.2/masonry.pkgd.min.js"></script>

--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -2,13 +2,14 @@
 <html>
   <head>
     <title>LittleShop</title>
-    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+
     <%= csrf_meta_tags %>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.5/css/materialize.min.css">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
    <!-- Compiled and minified JavaScript -->
    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.5/js/materialize.min.js"></script>
+   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
+   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
 
    <!-- Load masonry files -->
    <script src="https://cdnjs.cloudflare.com/ajax/libs/masonry/3.3.2/masonry.pkgd.min.js"></script>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,6 @@
 <h1><%= current_user.first_name %>'s Profile</h1>
 
-<p>Name: <%= current_user.first_name %> <%= current_user.last_name %></p>
-<p>Username: <%= current_user.username %></p>
+<h4>Name: <%= current_user.first_name %> <%= current_user.last_name %></h4>
+<h4>Username: <%= current_user.username %></h4>
+
+<h5><%= link_to "View Past Orders", orders_path %></h5>


### PR DESCRIPTION
You can now click on 'logged in as <name>' to be taken to the user's dashboard. The link is green so it stands out from the others. Additionally, the user's show page now has a link to view all of the user's past orders so they are easily accessible.

I also moved the stylesheets to below the materialize stylesheets, which I could have sworn I did yesterday but they somehow made it back there.

