### PR TITLE
closes #57 Add categories index to view items by category

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -86,6 +86,10 @@ img {
   opacity: 0.8;
 }
 
+.card .card-action a:not(.btn):not(.btn-large):not(.btn-floating) {
+  margin-right: 0;
+}
+
 /* Flash Messages */
 
 .flash_success {

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -3,6 +3,10 @@ class CategoriesController < ApplicationController
     @category = Category.find_by_slug(params[:slug])
   end
 
+  def index
+    @categories = Category.all.includes(:items)
+  end
+
   private
 
   def category_params

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,0 +1,8 @@
+<% @categories.each do |category| %>
+  <h3><%= category.name %></h3>
+  <div id="<%= category.name %>" class="grid">
+    <% category.items.each do |item| %>
+      <%= render partial: 'shared/item_card', locals: { item: item } %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -14,7 +14,7 @@
       <% end %>
       <li><%= link_to "View All Items", items_path %></li>
       <li><%= link_to "Browse by Artist", items_path %></li>
-      <li><%= link_to "Browse by Category", items_path %></li>
+      <li><%= link_to "Browse by Category", categories_path %></li>
     </ul>
   </div>
 </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   resources :items, only: [:index, :show]
-  resources :categories, only: [:show], param: :slug
+  resources :categories, only: [:show, :index], param: :slug
   resources :users, only: [:index, :new, :create]
   resources :cart_items, only: [:create, :destroy, :update]
   resources :orders, only: [:index, :create, :show]

--- a/test/integration/guest_can_view_items_sorted_by_category_test.rb
+++ b/test/integration/guest_can_view_items_sorted_by_category_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class GuestCanViewItemsSortedByCategoryTest < ActionDispatch::IntegrationTest
+  test "items are shown under their assigned category" do
+    category1 = create(:category_with_items)
+    category2 = create(:category_with_items)
+
+    visit categories_path
+
+    assert page.has_content?(category1.name)
+    within "\##{category1.name}" do
+      assert page.has_content?(category1.items.first.title)
+      assert page.has_content?(category1.items.last.title)
+      refute page.has_content?(category2.items.first.title)
+      refute page.has_content?(category2.items.last.title)
+    end
+
+    assert page.has_content?(category2.name)
+    within "\##{category2.name}" do
+      assert page.has_content?(category2.items.first.title)
+      assert page.has_content?(category2.items.last.title)
+      refute page.has_content?(category1.items.first.title)
+      refute page.has_content?(category1.items.last.title)
+    end
+  end
+end


### PR DESCRIPTION
Also updates the navbar so that the "Browse by Category" link goes to the categories path.

Includes a test for this view. Uses the item_card partial in the shared folder and incorporates the masonry grid so it looks a lot like the items index, just sorted by category.