### PR TITLE
[WIP - DO NOT MERGE] closes #58 add index for items by artist

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -1,0 +1,5 @@
+class ArtistsController < ApplicationController
+  def index
+    @artists = Artist.all.includes(:items)
+  end
+end

--- a/app/views/artists/index.html.erb
+++ b/app/views/artists/index.html.erb
@@ -1,0 +1,3 @@
+<% @artists.each do |artist| %>
+  
+<% end %>

--- a/app/views/artists/index.html.erb
+++ b/app/views/artists/index.html.erb
@@ -1,3 +1,8 @@
 <% @artists.each do |artist| %>
-  
+<h3><%= artist.first_name %> <%= artist.last_name %></h3>
+<div id="artist_<%= artist.id %>" class="grid">
+  <% artist.items.each do |item| %>
+    <%= render partial: 'shared/item_card', locals: { item: item } %>
+  <% end %>
+</div>
 <% end %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -13,7 +13,7 @@
         <li><%= link_to "Login", login_path %></li>
       <% end %>
       <li><%= link_to "View All Items", items_path %></li>
-      <li><%= link_to "Browse by Artist", items_path %></li>
+      <li><%= link_to "Browse by Artist", artists_path %></li>
       <li><%= link_to "Browse by Category", items_path %></li>
     </ul>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :new, :create]
   resources :cart_items, only: [:create, :destroy, :update]
   resources :orders, only: [:index, :create, :show]
+  resources :artists, only: [:index]
 
   get "/cart", to: "cart_items#index"
   get "/login", to: "sessions#new"

--- a/test/integration/guest_can_view_items_sorted_by_artist_test.rb
+++ b/test/integration/guest_can_view_items_sorted_by_artist_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class GuestCanViewItemsSortedByArtistTest < ActionDispatch::IntegrationTest
   test "items are shown under their assigned artist" do
@@ -7,16 +7,16 @@ class GuestCanViewItemsSortedByArtistTest < ActionDispatch::IntegrationTest
 
     visit artists_path
 
-    assert page.has_content?(artist1.name)
-    within "\##{artist1.name}" do
+    assert page.has_content?("#{artist1.first_name} #{artist1.last_name}")
+    within "\#artist_#{artist1.id}" do
       assert page.has_content?(artist1.items.first.title)
       assert page.has_content?(artist1.items.last.title)
       refute page.has_content?(artist2.items.first.title)
       refute page.has_content?(artist2.items.last.title)
     end
 
-    assert page.has_content?(artist2.name)
-    within "\##{artist2.name}" do
+    assert page.has_content?("#{artist2.first_name} #{artist2.last_name}")
+    within "\#artist_#{artist2.id}" do
       assert page.has_content?(artist2.items.first.title)
       assert page.has_content?(artist2.items.last.title)
       refute page.has_content?(artist1.items.first.title)

--- a/test/integration/guest_can_view_items_sorted_by_artist_test.rb
+++ b/test/integration/guest_can_view_items_sorted_by_artist_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class GuestCanViewItemsSortedByArtistTest < ActionDispatch::IntegrationTest
+  test "items are shown under their assigned artist" do
+    artist1 = create(:artist_with_items)
+    artist2 = create(:artist_with_items)
+
+    visit artists_path
+
+    assert page.has_content?(artist1.name)
+    within "\##{artist1.name}" do
+      assert page.has_content?(artist1.items.first.title)
+      assert page.has_content?(artist1.items.last.title)
+      refute page.has_content?(artist2.items.first.title)
+      refute page.has_content?(artist2.items.last.title)
+    end
+
+    assert page.has_content?(artist2.name)
+    within "\##{artist2.name}" do
+      assert page.has_content?(artist2.items.first.title)
+      assert page.has_content?(artist2.items.last.title)
+      refute page.has_content?(artist1.items.first.title)
+      refute page.has_content?(artist1.items.last.title)
+    end
+  end
+end


### PR DESCRIPTION
Allows the user to "Browse by Artist" by creating an artist's index page. I had to add the artists_controller file and a folder for artist views. I'm sure we'll use this more in the future. It also updates the navbar link so "Browse by Artist" goes to the new page. Includes a passing test for this functionality.