### PR TITLE
closes #71 admin user dashboard

### DIFF
--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,1 @@
+<h2>Admin Dashboard</h2>

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -38,6 +38,12 @@ FactoryGirl.define do
     last_name
     username "user"
     password "password"
+    role 0
+
+    factory :admin do
+      username "admin"
+      role 2
+    end
   end
 
   sequence :name, %w(a b c).cycle do |n|

--- a/test/integration/admin_can_login_to_admin_dashboard_test.rb
+++ b/test/integration/admin_can_login_to_admin_dashboard_test.rb
@@ -2,11 +2,7 @@ require "test_helper"
 
 class AdminCanLoginToAdminDashboardTest < ActionDispatch::IntegrationTest
   test "admins logs in and sees admin dashboard" do
-    admin = User.create(first_name: "Admin",
-                     last_name: "Admin",
-                     username: "admin",
-                     password: "password",
-                     role: 2)
+    admin = create(:admin)
 
     visit login_path
     fill_in "Username", with: admin.username

--- a/test/integration/viewing_admin_dashboard_test.rb
+++ b/test/integration/viewing_admin_dashboard_test.rb
@@ -1,20 +1,26 @@
-require 'test_helper'
+require "test_helper"
 
 class ViewingAdminDashboardTest < ActionDispatch::IntegrationTest
-  test "admin can view the admin dashboard when logged in" do
+  test "registered admin can view the admin dashboard when logged in" do
     admin = create(:admin)
-    byebug
+    ApplicationController.any_instance.stubs(:current_user).returns(admin)
 
-    # As an Admin
-    # When I visit "/admin/dashboard"
-    # I will see a heading on the page that says "Admin Dashboard"
-    #
-    # As a registered user
-    # When I visit "/admin/dashboard"
-    # I get a 404
-    #
-    # As an unregistered user
-    # When I visit "/admin/dashboard"
-    # I get a 404
+    visit admin_dashboard_path
+    assert page.has_content?("Admin Dashboard")
+  end
+
+  test "registered user cannot view the admin dashboard when logged in" do
+    user = create(:user)
+    ApplicationController.any_instance.stubs(:current_user).returns(user)
+
+    visit admin_dashboard_path
+    message_404 = "The page you were looking for doesn't exist (404)"
+    assert page.has_content?(message_404)
+  end
+
+  test "unregistered user cannot view the admin dashboard" do
+    visit admin_dashboard_path
+    message_404 = "The page you were looking for doesn't exist (404)"
+    assert page.has_content?(message_404)
   end
 end

--- a/test/integration/viewing_admin_dashboard_test.rb
+++ b/test/integration/viewing_admin_dashboard_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class ViewingAdminDashboardTest < ActionDispatch::IntegrationTest
+  test "admin can view the admin dashboard when logged in" do
+    admin = create(:admin)
+    byebug
+
+    # As an Admin
+    # When I visit "/admin/dashboard"
+    # I will see a heading on the page that says "Admin Dashboard"
+    #
+    # As a registered user
+    # When I visit "/admin/dashboard"
+    # I get a 404
+    #
+    # As an unregistered user
+    # When I visit "/admin/dashboard"
+    # I get a 404
+  end
+end


### PR DESCRIPTION
Only a logged in admin can view the admin dashboard, which currently just says "Admin Dashboard" on it. Everyone else is redirected to a 404 page. The there are 3 tests that cover the use case: 1 for logged in admin, 1 for logged in user, 1 for unregistered user.