### PR TITLE
Remove artists table

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,5 +1,0 @@
-class Artist < ActiveRecord::Base
-  has_many :items
-  validates :first_name, presence: true
-  validates :last_name, presence: true
-end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,10 +3,19 @@ class Item < ActiveRecord::Base
   belongs_to :category
   has_many :order_items
   has_many :orders, through: :order_items
+
   validates :title, presence: true
   validates :image_path, presence: true
   validates :user_id, presence: true
   validates :category_id, presence: true
   validates :price, presence: true
   validates :description, presence: true
+
+  before_save :check_user_type
+
+  private
+
+  def check_user_type
+    User.find(user_id).artist?
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,11 +1,11 @@
 class Item < ActiveRecord::Base
-  belongs_to :artist
+  belongs_to :user
   belongs_to :category
   has_many :order_items
   has_many :orders, through: :order_items
   validates :title, presence: true
   validates :image_path, presence: true
-  validates :artist_id, presence: true
+  validates :user_id, presence: true
   validates :category_id, presence: true
   validates :price, presence: true
   validates :description, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ActiveRecord::Base
   validates :first_name, presence: true
   validates :last_name, presence: true
   has_many :orders
+  has_many :items
 
   enum role: %w(default artist admin)
 end

--- a/app/views/cart_items/_item.html.erb
+++ b/app/views/cart_items/_item.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div class="col m8 s12 left-align">
     <h5>
-      <%= item.title %> by <%= item.artist.first_name %> <%= item.artist.last_name %>
+      <%= item.title %> by <%= item.user.first_name %> <%= item.user.last_name %>
     </h5>
 
     <p><%= item.description %></p>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
   </div>
   <div class="col m6 s12">
     <h4><%= @item.title %></h4> <br> by <br>
-    <h5><%= @item.artist.first_name %> <%= @item.artist.last_name %></h5>
+    <h5><%= @item.user.first_name %> <%= @item.user.last_name %></h5>
     <p>
       <%= @item.price %>
     </p>

--- a/db/migrate/20160115171327_add_user_id_to_items.rb
+++ b/db/migrate/20160115171327_add_user_id_to_items.rb
@@ -1,0 +1,5 @@
+class AddUserIdToItems < ActiveRecord::Migration
+  def change
+    add_reference :items, :user, index: true, foreign_key: true
+  end
+end

--- a/db/migrate/20160115171653_remove_artist_from_items.rb
+++ b/db/migrate/20160115171653_remove_artist_from_items.rb
@@ -1,0 +1,5 @@
+class RemoveArtistFromItems < ActiveRecord::Migration
+  def change
+    remove_reference :items, :artist, index: true, foreign_key: true
+  end
+end

--- a/db/migrate/20160115171852_drop_artists.rb
+++ b/db/migrate/20160115171852_drop_artists.rb
@@ -1,0 +1,5 @@
+class DropArtists < ActiveRecord::Migration
+  def change
+    drop_table :artists
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,17 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160114222006) do
+ActiveRecord::Schema.define(version: 20160115171852) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "artists", force: :cascade do |t|
-    t.string   "first_name"
-    t.string   "last_name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
 
   create_table "categories", force: :cascade do |t|
     t.string   "name"
@@ -33,16 +26,16 @@ ActiveRecord::Schema.define(version: 20160114222006) do
   create_table "items", force: :cascade do |t|
     t.string   "title"
     t.string   "image_path"
-    t.integer  "artist_id"
     t.integer  "category_id"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
     t.integer  "price"
     t.text     "description"
+    t.integer  "user_id"
   end
 
-  add_index "items", ["artist_id"], name: "index_items_on_artist_id", using: :btree
   add_index "items", ["category_id"], name: "index_items_on_category_id", using: :btree
+  add_index "items", ["user_id"], name: "index_items_on_user_id", using: :btree
 
   create_table "order_items", force: :cascade do |t|
     t.integer  "order_id"
@@ -73,8 +66,8 @@ ActiveRecord::Schema.define(version: 20160114222006) do
     t.integer  "role",            default: 0
   end
 
-  add_foreign_key "items", "artists"
   add_foreign_key "items", "categories"
+  add_foreign_key "items", "users"
   add_foreign_key "order_items", "items"
   add_foreign_key "order_items", "orders"
   add_foreign_key "orders", "users"

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -1,23 +1,10 @@
 FactoryGirl.define do
-  factory :artist do
-    first_name
-    last_name
-    factory :artist_with_items do
-      transient do
-        item_count 2
-      end
-      after(:create) do |artist, evaluator|
-        create_list(:item, evaluator.item_count, artist: artist)
-      end
-    end
-  end
-
   factory :item do
     price
     description "This is a painting of Batman."
     title
     image_path "https://s-media-cache-ak0.pinimg.com/236x/ac/79/ec/ac79ecfd60f82e28cabdfb8f1dc10df4.jpg"
-    artist
+    user
     category
   end
 
@@ -44,6 +31,28 @@ FactoryGirl.define do
       username "admin"
       role 2
     end
+
+    factory :artist do
+      username { generate(:artist_username) }
+      password "password"
+      role 1
+
+      factory :artist_with_items do
+        transient do
+          item_count 2
+        end
+
+        after(:create) do |user, evaluator|
+          create_list(:item, evaluator.item_count, user: user)
+        end
+      end
+    end
+  end
+
+
+
+  sequence :artist_username do |n|
+    "artist#{n}"
   end
 
   sequence :name, %w(a b c).cycle do |n|

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     description "This is a painting of Batman."
     title
     image_path "https://s-media-cache-ak0.pinimg.com/236x/ac/79/ec/ac79ecfd60f82e28cabdfb8f1dc10df4.jpg"
-    user
+    association :user, factory: :artist
     category
   end
 
@@ -14,6 +14,7 @@ FactoryGirl.define do
       transient do
         item_count 2
       end
+
       after(:create) do |category, evaluator|
         create_list(:item, evaluator.item_count, category: category)
       end
@@ -34,7 +35,6 @@ FactoryGirl.define do
 
     factory :artist do
       username { generate(:artist_username) }
-      password "password"
       role 1
 
       factory :artist_with_items do
@@ -48,8 +48,6 @@ FactoryGirl.define do
       end
     end
   end
-
-
 
   sequence :artist_username do |n|
     "artist#{n}"

--- a/test/models/artist_test.rb
+++ b/test/models/artist_test.rb
@@ -1,6 +1,0 @@
-require "test_helper"
-
-class ArtistTest < ActiveSupport::TestCase
-  should validate_presence_of(:first_name)
-  should validate_presence_of(:last_name)
-end

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class ItemTest < ActiveSupport::TestCase
   should validate_presence_of(:title)
   should validate_presence_of(:image_path)
-  should validate_presence_of(:artist_id)
+  should validate_presence_of(:user_id)
   should validate_presence_of(:category_id)
   should validate_presence_of(:price)
   should validate_presence_of(:description)

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -7,4 +7,40 @@ class ItemTest < ActiveSupport::TestCase
   should validate_presence_of(:category_id)
   should validate_presence_of(:price)
   should validate_presence_of(:description)
+
+  test "item can belong to an artist" do
+    artist = create(:artist)
+    category = create(:category)
+    artist.items.create(title: "Title",
+                        description: "Description",
+                        price: 10,
+                        category_id: category.id,
+                        image_path: "http://example.jpg")
+
+    assert_equal 1, artist.items.count
+  end
+
+  test "item cannot belong to a regular user" do
+    user = create(:user)
+    category = create(:category)
+    user.items.create(title: "Title",
+                      description: "Description",
+                      price: 10,
+                      category_id: category.id,
+                      image_path: "http://example.jpg")
+
+    assert_equal 0, user.items.count
+  end
+
+  test "item cannot belong to an admin" do
+    admin = create(:admin)
+    category = create(:category)
+    admin.items.create(title: "Title",
+                      description: "Description",
+                      price: 10,
+                      category_id: category.id,
+                      image_path: "http://example.jpg")
+
+    assert_equal 0, admin.items.count
+  end
 end


### PR DESCRIPTION
Instead of having an artist's table and model, we made artist a type of user with role = 1. We had to update a lot in factory girl and the models to get this to work. In addition we added model tests so that ONLY a user with the role of artist can be assigned to an item.  Admins should still be able to create items, but they will have to assign the item to an existing artist in the database (aka a user with the role of 1). Users with a default role of 0 cannot be assigned to an item through the item's user_id. We ended out using a before_save callback to implement this functionality.