### PR TITLE
closes #84 Category names are now links to their show pages

### DIFF
--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,5 +1,5 @@
 <% @categories.each do |category| %>
-  <h2><%= category.name %></h2>
+  <h2><%= link_to category.name, category_path(category) %></h2>
   <div id="<%= category.name %>" class="grid">
     <% category.items.each do |item| %>
       <%= render partial: 'shared/item_card', locals: { item: item } %>


### PR DESCRIPTION
Super easy pull request. On the "Browse by Category" index page, the category names now link to the individual show pages. The links are blue, which looks kind of nice, but we can change them to black again if you guys want.