### PR TITLE
closes #89 User can go from artists index to artist show page

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -1,5 +1,9 @@
 class ArtistsController < ApplicationController
   def index
-    @artists = User.artists
+    @artists = User.artists.includes(:items)
+  end
+
+  def show
+    @artist = User.artists.find(params[:id])
   end
 end

--- a/app/views/artists/index.html.erb
+++ b/app/views/artists/index.html.erb
@@ -1,5 +1,5 @@
 <% @artists.each do |artist| %>
-  <h2><%= artist.full_name %></h2>
+  <h2><%= link_to artist.full_name, artist_path(artist) %></h2>
   <div id="<%= artist.username %>" class="grid">
     <% artist.items.each do |item| %>
       <%= render partial: 'shared/item_card', locals: { item: item } %>

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -1,0 +1,7 @@
+<h2> <%= @artist.full_name %> </h2>
+
+<div class="grid">
+  <% @artist.items.each do |item| %>
+    <%= render partial: "shared/item_card", locals: { item: item } %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
     resources :items, only: [:new, :create, :edit, :update, :index, :show]
   end
 
-  get "/artists", to: "artists#index"
+  resources :artists, only: [:index, :show]
 
   get "/cart", to: "cart_items#index"
   get "/login", to: "sessions#new"

--- a/test/integration/user_can_view_items_from_an_individual_artist_test.rb
+++ b/test/integration/user_can_view_items_from_an_individual_artist_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class UserCanViewItemsFromAnIndividualArtistTest < ActionDispatch::IntegrationTest
+  test "user sees only items from the specific artist" do
+    artist1 = create(:artist_with_items)
+    artist2 = create(:artist_with_items)
+
+    visit artists_path
+    click_link artist1.full_name
+
+    assert_equal artist_path(artist1), current_path
+
+    assert page.has_content?("#{artist1.items.first.title}")
+    assert page.has_content?("#{artist1.items.last.title}")
+    refute page.has_content?("#{artist2.items.first.title}")
+    refute page.has_content?("#{artist2.items.last.title}")
+  end
+end

--- a/test/integration/user_sees_items_by_category_test.rb
+++ b/test/integration/user_sees_items_by_category_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class UserSeesItemsByCategoryTest < ActionDispatch::IntegrationTest
   test "user sees only items specified by category" do


### PR DESCRIPTION
Allows the user to click on an artist's full name from the artist index to be taken to their show page. 

@martensonbj I didn't slug this because I was having issues with it, maybe you can figure out how? I think if we slugged the artists path, since an artist is really just a user, we would have to slug the user paths also (which got confusing to me).