### PR TITLE
Allow admin to change status of order from index

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -2,4 +2,10 @@ class Admin::OrdersController < Admin::BaseController
   def index
     @orders = Order.all
   end
+
+  def update
+    Order.find(params[:id]).update_attribute(:status, params[:status].to_i)
+
+    redirect_to admin_orders_path
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -18,4 +18,20 @@ class Order < ActiveRecord::Base
   def quantity_of_item(item_id)
     order_items.find_by(item_id: item_id).quantity
   end
+
+  def self.count_of_ordered
+    where(status: 0).count
+  end
+
+  def self.count_of_paid
+    where(status: 1).count
+  end
+
+  def self.count_of_cancelled
+    where(status: 2).count
+  end
+
+  def self.count_of_completed
+    where(status: 3).count
+  end
 end

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -1,21 +1,46 @@
 <h2>All Orders</h2>
+<div id= "totals" class="row center-align">
+  <div class="col s3 status_ordered">
+    <p>Ordered: <%= @orders.count_of_ordered %></p>
+  </div>
+  <div class="col s3 status_paid">
+    <p>Paid: <%= @orders.count_of_paid %></p>
+  </div>
+  <div class="col s3 status_completed">
+    <p>Completed: <%= @orders.count_of_completed %></p>
+  </div>
+  <div class="col s3 status_cancelled">
+    <p>Cancelled: <%= @orders.count_of_cancelled %></p>
+  </div>
+</div>
+
 <table class="highlight">
   <thead>
     <tr>
-        <th data-field="id">Order ID</th>
-        <th data-field="name">Username</th>
-        <th data-field="status">Order Status</th>
-        <th data-field="price">Date</th>
+      <th>Order ID</th>
+      <th>Username</th>
+      <th>Order Status</th>
+      <th>Date</th>
+      <th>Update Status</th>
     </tr>
   </thead>
   <tbody>
   <% @orders.reverse.each do |order| %>
-      <tr id="order_<%= order.id %>" data-link="<%= user_order_path(order.user, order) %>">
-      <td><%= order.id %></td>
-      <td><%= order.user.username  %></td>
-      <td class="status_<%=order.status%>"><%= order.status %></td>
-      <td><%= order.date %></td>
-    </tr>
+      <tr id="order_<%= order.id %>">
+        <td><%= link_to order.id, user_order_path(order.user, order) %></td>
+        <td><%= order.user.username  %></td>
+        <td class="status_<%=order.status%>"><%= order.status %></td>
+        <td><%= order.date %></td>
+        <td>
+          <% if order.ordered? %>
+            <%= link_to "Mark as Paid", admin_order_path(order, status: 1), method: :put %>
+            <%= link_to "Cancel", admin_order_path(order, status: 2), method: :put %>
+          <% elsif order.paid? %>
+            <%= link_to "Mark as Completed", admin_order_path(order, status: 3), method: :put %>
+            <%= link_to "Cancel", admin_order_path(order, status: 2), method: :put %>
+          <% end %>
+        </td>
+      </tr>
     <% end %>
   </tbody>
 </table>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,20 +32,15 @@
   </script>
 
   <script type="text/javascript">
-  $(document).ready(function() {
-    $('select').material_select();
-});
-</script>
+    $(document).ready(function() {
+      $('select').material_select();
+    });
+  </script>
 
   <script type="text/javascript">
-  $( document ).ready(function(){
-    $(".button-collapse").sideNav();
-  })
-  </script>
-  <script>
-  $("tr").click(function() {
-    window.location = $(this).data("link")
-  })
+    $( document ).ready(function(){
+      $(".button-collapse").sideNav();
+    })
   </script>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   namespace :admin do
     get "/dashboard", to: "users#show"
     resources :items, only: [:new, :create, :edit, :update, :index, :show]
-    resources :orders, only: [:index]
+    resources :orders, only: [:index, :update]
   end
 
   resources :artists, only: [:index, :show]

--- a/test/factories/factories.rb
+++ b/test/factories/factories.rb
@@ -72,11 +72,15 @@ FactoryGirl.define do
 
   factory :order do
     user
-    status "ordered"
+    status
   end
 
   sequence :artist_username do |n|
     "artist#{n}"
+  end
+
+  sequence :status, %w(ordered paid cancelled completed).cycle do |n|
+    n
   end
 
   sequence :name, %w(a b c).cycle do |n|

--- a/test/integration/admin_views_all_orders_test.rb
+++ b/test/integration/admin_views_all_orders_test.rb
@@ -2,24 +2,45 @@ require "test_helper"
 
 class AdminViewsAllOrdersTest < ActionDispatch::IntegrationTest
   test "admin can view any order orders" do
-    # admin = create(:admin)
-    # order = Order.find(create(:order_item).order_id)
-    # user = order.user
-    # item = order.items.first
-    # ApplicationController.any_instance.stubs(:current_user).returns(admin)
-    #
-    # visit admin_dashboard_path
-    # click_on "View Orders"
-    # assert_equal admin_orders_path, current_path
-    # find("#order_#{Order.last.id}").click
+    admin = create(:admin)
+    order_items = create_list(:order_item, 4)
+    order1, order2, order3, order4 = order_items.map(&:order)
+    order1.ordered!
+    order2.paid!
+    order3.cancelled!
+    order4.completed!
 
-    # visit admin_order_path(Order.last)
+    ApplicationController.any_instance.stubs(:current_user).returns(admin)
 
-    # assert page.has_content? user.first_name
-    # assert page.has_content? user.last_name
-    # assert page.has_content? user.email_address
-    # assert page.has_content? user.street_address
-    # assert page.has_content? user.city
-    # assert page.has_link? item.title, href: item_path(item)
+    visit admin_dashboard_path
+    click_on "View Orders"
+
+    assert_equal admin_orders_path, current_path
+
+    within "#totals" do
+      assert page.has_content? "Ordered: 1"
+      assert page.has_content? "Paid: 1"
+      assert page.has_content? "Cancelled: 1"
+      assert page.has_content? "Completed: 1"
+    end
+
+    assert page.has_link? order1.id, href: user_order_path(order1.user, order1)
+    assert page.has_link? order2.id, href: user_order_path(order2.user, order2)
+    assert page.has_link? order3.id, href: user_order_path(order3.user, order3)
+    assert page.has_link? order4.id, href: user_order_path(order4.user, order4)
+
+    click_link "Mark as Paid"
+    assert_equal admin_orders_path, current_path
+    within "#order_#{order1.id}" do
+      assert page.has_content? "paid"
+    end
+
+    within "#order_#{order2.id}" do
+      click_link "Cancel"
+    end
+    assert_equal admin_orders_path, current_path
+    within "#order_#{order2.id}" do
+      assert page.has_content? "cancelled"
+    end
   end
 end


### PR DESCRIPTION
From the admin's view of all of the orders, they now have links to change the status of an order that is 'ordered' or 'paid'. This hits the update method in the admin orders controller. The order then changes and the admin is redirected back to the orders index. Includes a passing test for this functionality.