### PR TITLE
Closes #114 Add styling to dashboard for user and admin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :set_cart
   helper_method :current_user
+  helper_method :current_admin?
 
   def set_cart
     @cart = Cart.new(session[:cart])

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,8 +1,3 @@
 <h2>Admin Dashboard</h2>
 
-<%= link_to "Create Item", new_admin_item_path %>
-<br>
-<%= link_to "View Items", admin_items_path %>
-<%= link_to "View Orders", admin_orders_path %>
-
 <%= render partial: "shared/user_info" %>

--- a/app/views/shared/_user_info.html.erb
+++ b/app/views/shared/_user_info.html.erb
@@ -26,6 +26,9 @@
           <h5><%= link_to "Create Item", new_admin_item_path %></h5>
           <h5><%= link_to "View Items", admin_items_path %></h5>
           <h5><%= link_to "View Orders", admin_orders_path %></h5>
+        <% elsif current_artist? %>
+          <h5><%= link_to "View My Items", artist_path(current_user) %></h5>
+          <h5><%= link_to "Add New Item", new_user_item_path(current_user) %></h5>
         <% end %>
       </div>
     </div>

--- a/app/views/shared/_user_info.html.erb
+++ b/app/views/shared/_user_info.html.erb
@@ -1,8 +1,33 @@
-<h4>Name: <%= current_user.first_name %> <%= current_user.last_name %></h4>
-<h4>Username: <%= current_user.username %></h4>
-<h4>Email: <%= current_user.email_address %></h4>
+<div class="row">
+  <div class="col s12 m6">
+    <div class="card">
+      <div class="card-content">
+        <h3><%= current_user.full_name %></h3>
+        <h5 class="left-align"><strong>Username: </strong><%= current_user.username %></h5>
+        <h5 class="left-align"><strong>Email: </strong><%= current_user.email_address %></h5>
+        <h5 class="left-align"><%= current_user.street_address %></h5>
+        <h5 class="left-align"><%= current_user.city %>, <%= current_user.state %> <%= current_user.zipcode %></h5>
+      </div>
+      <div class="card-action">
+        <%= link_to "Edit Info", edit_user_path(current_user), class: "btn waves-effect waves-light" %>
+      </div>
+    </div>
+  </div>
 
-<h4>Address:</h4>
-<h5><%= current_user.street_address %></h5>
-<h5><%= current_user.city %>, <%= current_user.state %> <%= current_user.zipcode %></h5>
-<%= link_to "Edit Info", edit_user_path(current_user) %>
+  <div class="col s12 m6">
+    <div class="card">
+      <div class="card-content">
+        <h3>Actions</h3>
+      </div>
+      <div class="card-action">
+        <h5><%= link_to "View Past Orders", user_orders_path(current_user.slug) %></h5>
+
+        <% if current_admin? %>
+          <h5><%= link_to "Create Item", new_admin_item_path %></h5>
+          <h5><%= link_to "View Items", admin_items_path %></h5>
+          <h5><%= link_to "View Orders", admin_orders_path %></h5>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,10 +1,3 @@
 <h2><%= current_user.first_name %>'s Profile</h2>
 
-<h5><%= link_to "View Past Orders", user_orders_path(current_user.slug) %></h5>
-
-<% if current_artist? %>
-  <h5><%= link_to "View My Items", artist_path(current_user) %></h5>
-  <h5><%= link_to "Add New Item", new_user_item_path(current_user) %></h5>
-<% end %>
-
 <%= render partial: "shared/user_info" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,3 @@
 <h2><%= current_user.first_name %>'s Profile</h2>
 
-<h5><%= link_to "View Past Orders", user_orders_path(current_user.slug) %></h5>
-
 <%= render partial: "shared/user_info" %>


### PR DESCRIPTION
Adds styling for the user/admin dashboard. Will need to update for the artist's dashboard once that branch is merged into master.

The dashboard is now separated out into two cards: the one on the left has the user info (and the edit button) and the one on the right has the user actions. The actions are different based on what the role of the current user is.

@martensonbj or @Tman22 can probably make it even prettier, but it at least looks a little better than it used to.