### PR TITLE
Remove username from edit user form

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -189,7 +189,7 @@ span.order_heading {
   margin-top: 2rem;
 }
 
-/* FORM STYLING */
+/***** FORM STYLING *****/
 
 form.profile_form {
     width: 80%;
@@ -231,6 +231,28 @@ textarea.materialize-textarea {
   font-size: 20px;
   font-weight: 300px;
   text-align: center;
+}
+
+/***** SIDE NAV ******/
+
+.side-nav {
+  background-color: rgba(0,0,0,0.7)
+}
+
+.side-nav a {
+  color: #7E8D94;
+}
+
+.side-nav a:hover {
+  background-color: transparent;
+  color: #fff;
+}
+.side-nav li {
+  border-bottom: 1px solid #303F46;
+}
+
+.side-nav li:hover {
+  background-color: rgba(89, 107, 115, 0.62);
 }
 
 @media screen only and (max-width: 990px) {

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -57,12 +57,12 @@
       <li><%= link_to "View Cart", cart_path %></li>
 
       <% if current_admin? %>
-        <li class="right-align">
-          <%= link_to "Logged in as #{current_user.first_name} (admin)", admin_dashboard_path(current_user.slug) , class: "login_confirm"%>
+        <li>
+          <%= link_to "Dashboard (#{current_user.first_name}: admin)", admin_dashboard_path(current_user.slug) , class: "login_confirm"%>
         </li>
       <% elsif current_user %>
-        <li class="right-align">
-          <%= link_to "Logged in as #{current_user.first_name}", dashboard_path(current_user.slug) , class: "login_confirm"%>
+        <li>
+          <%= link_to "Dashboard (#{current_user.first_name})", dashboard_path(current_user.slug) , class: "login_confirm"%>
         </li>
       <% end %>
 

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -28,9 +28,11 @@
   <%= f.label :zipcode %>
   <%= f.text_field :zipcode %>
   <br>
-
-  <%= f.label :username %>
-  <%= f.text_field :username  %>
+  
+  <% if @user != current_user %>
+    <%= f.label :username %>
+    <%= f.text_field :username  %>
+  <% end %>
   <br>
 
   <%= f.label :password %>

--- a/test/integration/user_cant_change_username_test.rb
+++ b/test/integration/user_cant_change_username_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class RegisteredUserCantChangeUsernameTest < ActionDispatch::IntegrationTest
+  test "registered users can edit all profile fields except username" do
+    visit new_user_path
+    assert page.has_content?("Username")
+
+    user = create(:user)
+    ApplicationController.any_instance.stubs(:current_user).returns(user)
+
+    visit edit_user_path(user)
+    refute page.has_content?("Username")
+  end
+end


### PR DESCRIPTION
As a registered user you can no longer edit your username. This prevents duplications down the road and issues with slugs in the URL. Usernames should be unique and permanent for each user. I also added a test to verify all this was working. Username is still visible on create new user view of form. 