### PR TITLE
Closes #126 Prevent user for manually visiting another user's edit path

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,7 @@ class UsersController < ApplicationController
 
   def create
     @user = User.new(user_params)
+
     if @user.save
       session[:user_id] = @user.id
       redirect_to dashboard_path
@@ -28,6 +29,7 @@ class UsersController < ApplicationController
   end
 
   def edit
+    render file: "public/404" unless user_slug_is_current_user
   end
 
   def update
@@ -63,5 +65,9 @@ class UsersController < ApplicationController
                                  :role,
                                  :slug,
                                  :file_upload)
+  end
+
+  def user_slug_is_current_user
+    current_user.slug == params[:slug]
   end
 end

--- a/test/integration/user_can_edit_their_info_test.rb
+++ b/test/integration/user_can_edit_their_info_test.rb
@@ -45,4 +45,16 @@ class UserCanEditTheirInfoTest < ActionDispatch::IntegrationTest
 
     assert page.has_content? "Incorrect user information"
   end
+
+  test "user cannot visit edit page for another user" do
+    user1 = create(:user)
+    user2 = create(:user)
+
+    ApplicationController.any_instance.stubs(:current_user).returns(user1)
+
+    visit edit_user_path(user2)
+
+    message_404 = "The page you were looking for doesn't exist (404)"
+    assert page.has_content? message_404
+  end
 end


### PR DESCRIPTION
Really quick addition to the UsersController which checks to make sure a user can't manually visit another user's edit path. The info showing up in the edit form was ALWAYS the current users's, but weirdly if I was logged in as 'toni_admin' I could manually edit the address bar to go to /users/brenna_artist/edit and it would allow me to do that. Now there's a check that will render a 404 page if the slug in the URL isn't the same as the current user's slug.