### PR TITLE
Closes #132 Items cannot be active with default image

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,7 +38,7 @@ class ItemsController < ApplicationController
     if @item.update(item_params)
       redirect_to @item
     else
-      flash[:error] = "All fields must be filled in."
+      flash.now[:error] = "All fields must be filled in."
       render :new
     end
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -23,6 +23,9 @@ class Item < ActiveRecord::Base
 
   enum status: %w(inactive active)
 
+  def default_image?
+    image_path == "https://www.weefmgrenada.com/images/na4.jpg"
+  end
   private
 
   def check_user_type
@@ -32,5 +35,9 @@ class Item < ActiveRecord::Base
   def check_image_path
     photo_not_available = "https://www.weefmgrenada.com/images/na4.jpg"
     self.image_path = photo_not_available if image_path.nil? || image_path.empty?
+
+    if image_path == photo_not_available
+      self.status = "inactive"
+    end
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -24,20 +24,31 @@ class Item < ActiveRecord::Base
   enum status: %w(inactive active)
 
   def default_image?
-    image_path == "https://www.weefmgrenada.com/images/na4.jpg"
+    image_path == default_image
   end
+
   private
+
+  def default_image
+    "https://www.weefmgrenada.com/images/na4.jpg"
+  end
 
   def check_user_type
     User.find(user_id).artist?
   end
 
   def check_image_path
-    photo_not_available = "https://www.weefmgrenada.com/images/na4.jpg"
-    self.image_path = photo_not_available if image_path.nil? || image_path.empty?
+    self.image_path = default_image if image_path_is_empty_or_nil
 
-    if image_path == photo_not_available
+    if default_image? && file_upload_file_name
+      self.image_path = ""
+      self.status = "active"
+    elsif default_image?
       self.status = "inactive"
     end
+  end
+
+  def image_path_is_empty_or_nil
+    image_path.nil? || image_path.empty?
   end
 end

--- a/app/views/shared/_item_card.html.erb
+++ b/app/views/shared/_item_card.html.erb
@@ -12,7 +12,7 @@
       <% if item.status == "active" %>
         <%= button_to "Add to Cart", cart_items_path(item_id: item.id), class: "btn waves-effect waves-light" %>
       <% else %>
-        <p class="red-text">This item is currently out of stock.</p>
+        <p class="red-text">This item is inactive.</p>
       <% end %>
 
       <% if current_admin? %>

--- a/app/views/shared/_item_show.html.erb
+++ b/app/views/shared/_item_show.html.erb
@@ -38,8 +38,10 @@
 
     <% if @item.active? %>
       <%= button_to "Add to Cart", cart_items_path(item_id: @item.id), class: "btn waves-effect waves-light" %>
+    <% elsif @item.default_image? %>
+      <p class="red-text">This item is inactive. <br> Please upload an image to change status.</p>
     <% else %>
-      <p class="red-text">This item is currently out of stock.</p>
+      <p class="red-text">This item is inactive.</p>
     <% end %>
   </div>
 </div>

--- a/test/integration/images_show_inactive_status_if_default_test.rb
+++ b/test/integration/images_show_inactive_status_if_default_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class ImagesShowInactiveStatusIfDefaultTest < ActionDispatch::IntegrationTest
+  test "images default to inactive if there is no image" do
+    artist = create(:artist)
+    category = create(:category)
+    ApplicationController.any_instance.stubs(:current_user).returns(artist)
+
+    visit dashboard_path
+    click_on "Add New Item"
+
+    assert_equal new_user_item_path(artist), current_path
+
+    fill_in "Title", with: "Meat"
+    fill_in "Price", with: "10"
+    fill_in "Description", with: "Salad? That's what my food eats"
+    select category.name, from: "item_category_id"
+    click_on "Create Item"
+    item = Item.last
+
+    assert_equal artist, item.user
+    assert_equal "https://www.weefmgrenada.com/images/na4.jpg", item.image_path
+    assert_equal item_path(item), current_path
+    assert_equal "inactive", item.status
+
+    visit edit_user_item_path(artist, item)
+    choose "Active"
+    click_on "Update Item"
+
+    assert_equal item_path(item), current_path
+    assert page.has_content? "Please upload an image to change status."
+    assert_equal "inactive", item.status
+  end
+end

--- a/test/integration/user_cant_add_inactive_items_to_cart_test.rb
+++ b/test/integration/user_cant_add_inactive_items_to_cart_test.rb
@@ -14,7 +14,7 @@ class UserCantAddInactiveItemsToCartTest < ActionDispatch::IntegrationTest
     assert page.has_content? "Status: inactive"
     assert page.has_content? "Edit"
     refute page.has_content? "Add to Cart"
-    assert page.has_content? "This item is currently out of stock."
+    assert page.has_content? "This item is inactive."
 
     user = create(:user)
     ApplicationController.any_instance.stubs(:current_user).returns(user)
@@ -22,10 +22,10 @@ class UserCantAddInactiveItemsToCartTest < ActionDispatch::IntegrationTest
     visit items_path
     refute page.has_content? "Add to Cart"
     refute page.has_content? "Edit"
-    assert page.has_content? "This item is currently out of stock."
+    assert page.has_content? "This item is inactive."
 
     click_on item.title
     refute page.has_content? "Add to Cart"
-    assert page.has_content? "This item is currently out of stock."
+    assert page.has_content? "This item is inactive."
   end
 end


### PR DESCRIPTION
As an artist if you create an item you must have an image to set the status to active. The default status will be automatically set to active and it is impossible to set the status to inactive with a default image. 

We added a method to the item model to check for default image. We also changed the flash message for inactive items to say "This item is inactive" vs "This item is out of stock". 
